### PR TITLE
GetTime test fix

### DIFF
--- a/strongcomms_test.go
+++ b/strongcomms_test.go
@@ -326,6 +326,11 @@ func TestGetTimeZero(t *testing.T) {
 	ctx = httptrace.WithClientTrace(ctx, httpTrace)
 
 	var tm time.Time
+	// BUGFIX: x509.isValid() in the runtime tests the provided time,
+	// and if zero, internally swaps to using time.Now(), which is
+	// undermining this test. So we have to mildly increase pass zero.
+	tm = tm.Add(time.Hour * 24)
+
 	tm2, err := client.GetTimeWithContext(tm, ctx)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
We used a zero time for testing GetTime's ability to discover the current time.  Turns out the Golang runtime has a special case check in x509.isValid() that tests for time.IsZero() and if so, substitutes time.Now() -- this is undermining our test of trying to use a known-bad time.

Fix is simply to add a little bit of time to our starting test time value.